### PR TITLE
Add HobIcon

### DIFF
--- a/src/components/HobIcon/icons.tsx
+++ b/src/components/HobIcon/icons.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+export interface IIconProps {
+  color?: string;
+}
+
+export const Lock: React.FC<IIconProps> = ({
+  color = "var(--hob-color--dark)"
+}) => (
+  <svg
+    viewBox="0 0 16 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    stroke={color}
+  >
+    <path
+      d="M15 9H1V19H15V9Z"
+      stroke="black"
+      stroke-width="2"
+      stroke-miterlimit="10"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M3 9V6C3 3.24 5.24 1 8 1C10.76 1 13 3.24 13 6V9"
+      stroke-width="2"
+      stroke-miterlimit="10"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </svg>
+);
+
+export const Close: React.FC<IIconProps> = ({
+  color = "var(--hob-color--dark)"
+}) => (
+  <svg viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg" fill={color}>
+    <path d="M14 2L9 7l5 5-2 2-5-5-5 5-2-2 5-5-5-5 2-2 5 5 5-5 2 2z" />
+  </svg>
+);

--- a/src/components/HobIcon/index.stories.tsx
+++ b/src/components/HobIcon/index.stories.tsx
@@ -1,0 +1,50 @@
+import styled from "@emotion/styled";
+import React from "react";
+import { HobIcon } from ".";
+import { HobTypography } from "../HobTypography";
+
+export default {
+  title: "Icon"
+};
+
+const Container = styled.div`
+  padding: 1rem;
+`;
+
+const Flex = styled.div`
+  display: flex;
+  align-items: baseline;
+  margin: 1rem 0;
+
+  .hob-typography {
+    margin: 0 1rem;
+    &--h4 {
+      width: 100px;
+      display: block;
+    }
+  }
+`;
+
+export const demo = () => (
+  <Container>
+    <Flex>
+      <HobTypography variant="h4">Lock</HobTypography>
+      <HobTypography variant="caption">sm</HobTypography>
+      <HobIcon size="sm" name="lock" />
+      <HobTypography variant="caption">md</HobTypography>
+      <HobIcon size="md" name="lock" />
+      <HobTypography variant="caption">lg</HobTypography>
+      <HobIcon size="lg" name="lock" />
+    </Flex>
+
+    <Flex>
+      <HobTypography variant="h4">Close</HobTypography>
+      <HobTypography variant="caption">sm</HobTypography>
+      <HobIcon size="sm" name="close" />
+      <HobTypography variant="caption">md</HobTypography>
+      <HobIcon size="md" name="close" />
+      <HobTypography variant="caption">lg</HobTypography>
+      <HobIcon size="lg" name="close" />
+    </Flex>
+  </Container>
+);

--- a/src/components/HobIcon/index.tsx
+++ b/src/components/HobIcon/index.tsx
@@ -1,0 +1,43 @@
+import styled from "@emotion/styled";
+import React from "react";
+import { Close, Lock } from "./icons";
+
+const Icons = {
+  close: Close,
+  lock: Lock
+};
+
+export interface IHobIconProps {
+  color?: string;
+  name: "lock" | "close";
+  size: "sm" | "md" | "lg";
+}
+
+const SIZES = {
+  lg: "3rem",
+  md: "1.5rem",
+  sm: "0.75rem"
+};
+interface ISvgProps {
+  size: "sm" | "md" | "lg";
+}
+const SvgContainer = styled.div<ISvgProps>`
+  width: ${({ size }) => SIZES[size]};
+  svg {
+    width: 100%;
+  }
+`;
+
+export const HobIcon: React.FC<IHobIconProps> = ({
+  color = "var(--hob-color--dark)",
+  name,
+  size
+}) => {
+  const Svg = Icons[name];
+
+  return (
+    <SvgContainer size={size}>
+      <Svg color={color} />
+    </SvgContainer>
+  );
+};


### PR DESCRIPTION
Adds the two icons from the spec as components.

![image](https://user-images.githubusercontent.com/19894032/63641994-c6d04a00-c685-11e9-98ec-d856f7744797.png)
