### PR TITLE
@components/HobLetters bugfix

### DIFF
--- a/src/components/Studio/index.tsx
+++ b/src/components/Studio/index.tsx
@@ -1,7 +1,7 @@
-import { HobLetters } from "@components/HobLetters";
 import styled from "@emotion/styled";
 import React from "react";
 import breakpoints from "../../breakpoints";
+import { HobLetters } from "../HobLetters";
 import { HobLink } from "../HobLink";
 import { HobTypography } from "../HobTypography";
 


### PR DESCRIPTION
Not sure why this is throwing the error:
```
 ERROR  Failed to compile with 1 errors                                                                            11:48:21 AM
⠀
This dependency was not found:
⠀
* @components/HobLetters in ./src/components/Studio/index.tsx
⠀
To install it, you can run: npm install --save @components/HobLetters
```

Likely something to do with the config for absolute module imports... will need to investigate.