### PR TITLE
Video bugfix

### DIFF
--- a/src/components/HobVideo/index.tsx
+++ b/src/components/HobVideo/index.tsx
@@ -388,6 +388,7 @@ export const HobVideo: React.FC<IVideoProps & HTMLProps<HTMLVideoElement>> = ({
 
   let videoToRender = (
     <Video
+      preload="auto"
       className="hob-video"
       ref={videoRef}
       onLoadedMetadata={withVideo(onMetaLoad)}
@@ -405,6 +406,7 @@ export const HobVideo: React.FC<IVideoProps & HTMLProps<HTMLVideoElement>> = ({
   if (children.props.type === MediaType.QUICKTIME) {
     videoToRender = (
       <Video
+        preload={"auto"}
         className="hob-video"
         ref={videoRef}
         onLoadedMetadata={withVideo(onMetaLoad)}


### PR DESCRIPTION
Tested on Safari and Chrome.

Quicktime videos are inconsistent across browsers - basically by using `src=` as opposed to `<source>` in this case, we're letting the browser figure out how to play the file, rather than just giving it one option, another approach could be to have multiple <source> options...
```
<video id="sampleMovie" width="640" height="360" preload controls>
    <source src="filename.mov" />
    <source src="filename.ogv" />
    <source src="filename.webm" />
</video>
```

I also added the preload = 'auto' option to the html player. 
